### PR TITLE
align answer fields with 'give feedback...'

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -45,7 +45,7 @@ body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow2_] {
     border-bottom: 0;
 }
 /* Bottom */
-body#page-question-type-varnumeric div[id^=fitem_id_][id*=syserrorpenalty_] {
+body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow3_] {
     background: #EEE;
     margin-bottom: 2em;
     margin-top: 0;
@@ -77,11 +77,14 @@ body#page-question-type-varnumeric div[id^=fitem_id_][id*=requirescinotation]  +
 body#page-question-type-varnumeric #fitem_id_answer_0 {
     margin-top: 1em;
 }
-body#page-question-type-varnumeric div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'],
-body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
-body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'] {
+body#page-question-type-varnumeric div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'] {
     position: absolute;
     left: -10000px;
     font-weight: normal;
     font-size: 1em;
+}
+body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
+body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'],
+body#page-question-type-varnumeric div[id^=fgroup_id_][id*=autofirerow3_] label[for^='id_syserrorpenalty_'] {
+    margin-left: 0; 
 }


### PR DESCRIPTION
Phil asked

Within each Answer box I would suggest that the bottom three lines should be indented to line up under "Give feedback...".

This commit addresses this request. Leaving separate from main bug in case a different fix is required. Specifically had to group the field 'syserrorpenalty' into a new group 'autofirerow3' to align the labels properly. This may not be the best solution.
