### PR TITLE
Adapt mobile app template to Ionic 5

### DIFF
--- a/mobile/varnum.html
+++ b/mobile/varnum.html
@@ -1,15 +1,19 @@
 <section ion-list *ngIf="question.text || question.text === ''" class="qtype-varnumeric">
-    <ion-item text-wrap>
-        <p>
-            <core-format-text [component]="component" [componentId]="componentId" [text]="question.text"></core-format-text>
-        </p>
+    <ion-item text-wrap class="ion-text-wrap">
+        <ion-label>
+            <p>
+                <core-format-text [component]="component" [componentId]="componentId" [text]="question.text"></core-format-text>
+            </p>
+        </ion-label>
     </ion-item>
-    <ion-item text-wrap *ngIf="question.ablock || question.ablock === ''" class="qtype-varnumunit">
-        <div>
+    <ion-item text-wrap *ngIf="question.ablock || question.ablock === ''" class="qtype-varnumunit ion-text-wrap">
+        <ion-label>
             <core-format-text [component]="component" [componentId]="componentId" [text]="question.ablock"></core-format-text>
-        </div>
+        </ion-label>
     </ion-item>
-    <ion-item text-wrap *ngIf="question.ousupsub" class="core-danger-item">
-        <p class="core-question-warning">{{ 'plugin.qtype_varnumeric.err_ousupsubnotsupportedonmobile' | translate }}</p>
+    <ion-item text-wrap *ngIf="question.ousupsub" class="core-danger-item ion-text-wrap">
+        <ion-label>
+            <p class="core-question-warning">{{ 'plugin.qtype_varnumeric.err_ousupsubnotsupportedonmobile' | translate }}</p>
+        </ion-label>
     </ion-item>
 </section>


### PR DESCRIPTION
Please notice I have NOT tested this changes. I didn't have enough time to learn how to configure the question type.

I usually create 2 templates, one for ionic3 and one for ionic5, but in this case the template is really simple and there are no conflicts between ionic3 and ionic5 markup, so I kept a single template that I think should work fine in both versions.