### PR TITLE
[#14] tests: Resolve test failure for 3.11

### DIFF
--- a/tests/stats_from_steps_walkthrough_test.php
+++ b/tests/stats_from_steps_walkthrough_test.php
@@ -32,6 +32,11 @@ require_once($CFG->dirroot . '/mod/quiz/report/default.php');
 require_once($CFG->dirroot . '/mod/quiz/report/statistics/report.php');
 require_once($CFG->dirroot . '/mod/quiz/report/reportlib.php');
 
+// Maintain support on main branch.
+if (class_exists('\mod_quiz\attempt_walkthrough_from_csv_test')) {
+    class_alias('\mod_quiz\attempt_walkthrough_from_csv_test', 'mod_quiz_attempt_walkthrough_from_csv_testcase');
+}
+
 /**
  * Quiz attempt walk through using data from csv file.
  *


### PR DESCRIPTION
Also maintains support for older versions as requested in this comment: https://github.com/moodleou/moodle-qtype_varnumeric/issues/14#issuecomment-1511243191

Closes #14. 
